### PR TITLE
Start Kafka cluster within tests (copied from vert-x3/vertx-kafka-cli…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,8 @@
 		<junit.version>4.12</junit.version>
 		<vertx-unit.version>3.2.1</vertx-unit.version>
 		<spring-boot.version>1.4.2.RELEASE</spring-boot.version>
+		<debezium.version>0.4.0</debezium.version>
+
 	</properties>
 
 	<dependencies>
@@ -64,6 +66,25 @@
 			<groupId>io.vertx</groupId>
 			<artifactId>vertx-unit</artifactId>
 			<version>${vertx-unit.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.debezium</groupId>
+			<artifactId>debezium-core</artifactId>
+			<version>${debezium.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.debezium</groupId>
+			<artifactId>debezium-core</artifactId>
+			<version>${debezium.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.kafka</groupId>
+			<artifactId>kafka_2.11</artifactId>
+			<version>${kafka.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/test/java/enmasse/kafka/bridge/BridgeTest.java
+++ b/src/test/java/enmasse/kafka/bridge/BridgeTest.java
@@ -49,7 +49,7 @@ import java.util.List;
 import java.util.Map;
 
 @RunWith(VertxUnitRunner.class)
-public class BridgeTest {
+public class BridgeTest extends KafkaClusterTestBase {
 	
 	private static final Logger LOG = LoggerFactory.getLogger(BridgeTest.class);
 

--- a/src/test/java/enmasse/kafka/bridge/KafkaClusterTestBase.java
+++ b/src/test/java/enmasse/kafka/bridge/KafkaClusterTestBase.java
@@ -1,0 +1,63 @@
+package enmasse.kafka.bridge;
+/*
+ * Copyright 2016 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import io.debezium.kafka.KafkaCluster;
+import io.debezium.util.Testing;
+import io.vertx.ext.unit.TestContext;
+
+/**
+ * Base class for tests providing a Kafka cluster
+ */
+public class KafkaClusterTestBase {
+
+  private static File dataDir;
+  protected static KafkaCluster kafkaCluster;
+
+  protected static KafkaCluster kafkaCluster() {
+    if (kafkaCluster != null) {
+      throw new IllegalStateException();
+    }
+    dataDir = Testing.Files.createTestingDirectory("cluster");
+    kafkaCluster = new KafkaCluster().usingDirectory(dataDir).withPorts(2181, 9092);
+    return kafkaCluster;
+  }
+
+  @BeforeClass
+  public static void setUp(TestContext ctx) throws IOException {
+    kafkaCluster = kafkaCluster().deleteDataPriorToStartup(true).addBrokers(1).startup();
+  }
+
+
+  @AfterClass
+  public static void tearDown(TestContext ctx) {
+    if (kafkaCluster != null) {
+      kafkaCluster.shutdown();
+      kafkaCluster = null;
+      boolean delete = dataDir.delete();
+      // If files are still locked and a test fails: delete on exit to allow subsequent test execution
+      if(!delete) {
+        dataDir.deleteOnExit();
+      }
+    }
+  }
+}


### PR DESCRIPTION
…ent)

The new files KafkaClusterTestBase.java and KafkaTestBase.java are copied straight from https://github.com/vert-x3/vertx-kafka-client/blob/master/src/test/java/io/vertx/kafka/client/tests/ which is also ASL 2 licensed.

