### PR TITLE
OffsetTracker

### DIFF
--- a/src/main/java/enmasse/kafka/bridge/SinkBridgeEndpoint.java
+++ b/src/main/java/enmasse/kafka/bridge/SinkBridgeEndpoint.java
@@ -451,7 +451,7 @@ public class SinkBridgeEndpoint implements BridgeEndpoint {
 		
 		if (partition == null && offset != null) {
 			// no meaning only offset without partition
-			condition = new ErrorCondition(Symbol.getSymbol(Bridge.AMQP_ERROR_NO_PARTITION_FILTER), "No partition filter specied");
+			condition = new ErrorCondition(Symbol.getSymbol(Bridge.AMQP_ERROR_NO_PARTITION_FILTER), "No partition filter specified");
 			return condition;
 		}
 		

--- a/src/main/java/enmasse/kafka/bridge/tracker/FullOffsetTracker.java
+++ b/src/main/java/enmasse/kafka/bridge/tracker/FullOffsetTracker.java
@@ -40,15 +40,31 @@ public class FullOffsetTracker<K, V> implements OffsetTracker<K, V> {
 	// Apache Kafka topic to track
 	private String topic;
 	
-	// map with offset settlement status for each partition
-	private Map<Integer, Map<Long, Boolean>> offsetSettlements;
+	/**
+	 * The state of a partition
+	 */
+	private static class PartitionState {
+		/** Insertion-ordered map of offset to settlement */
+		public Map<Long, Boolean> settlements;
+		/** The current offset of this partition */
+		public long offset;
+		// has this message been received by remote AMQP peer
+		public boolean flag;
+		
+		public long firstUnsettled;
+		
+		public PartitionState(long offset) {
+			this.settlements = new LinkedHashMap<>();
+			this.settlements.put(offset, false);
+			this.firstUnsettled = offset;
+			
+			this.offset = -1;
+			this.flag = false;
+		}
+		
+	}
 	
-	// map with each partition and related tracked offset 
-	private Map<Integer, Long> offsets;
-	// map with changed status of offsets
-	private Map<Integer, Boolean> offsetsFlag;
-	// map with each partition and related first UNSETTLED offset
-	private Map<Integer, Long> firstUnsettledOffsets;
+	private Map<Integer, PartitionState> map;
 	
 	/**
 	 * Contructor
@@ -58,31 +74,16 @@ public class FullOffsetTracker<K, V> implements OffsetTracker<K, V> {
 	public FullOffsetTracker(String topic) {
 		
 		this.topic = topic;
-		this.offsetSettlements = new HashMap<>();
-		this.offsets = new HashMap<>();
-		this.offsetsFlag = new HashMap<>();
-		this.firstUnsettledOffsets = new HashMap<>();
+		this.map = new HashMap<>();
 	}
 	
 	@Override
 	public synchronized void track(int partition, long offset, ConsumerRecord<K, V> record) {
-		
-		if (!this.offsetSettlements.containsKey(partition)) {
-			
-			// new partition to track, create new related offset settlements map
-			Map<Long, Boolean> offsets = new LinkedHashMap<>();
-			// the offset in UNSETTLED
-			offsets.put(offset, false);
-			
-			this.offsetSettlements.put(partition, offsets);
-			
-			// this is the first UNSETTLED offset for the partition (just created)
-			this.firstUnsettledOffsets.put(partition, offset);
-			
+		PartitionState state = this.map.get(partition);
+		if (state == null) {
+			this.map.put(partition, new PartitionState(offset));
 		} else {
-			
-			// partition already tracked, new offset is UNSETTLED
-			this.offsetSettlements.get(partition).put(offset, false);
+			state.settlements.put(offset, false);
 		}
 	}
 
@@ -90,48 +91,45 @@ public class FullOffsetTracker<K, V> implements OffsetTracker<K, V> {
 	public synchronized void delivered(int partition, long offset) {
 		
 		// offset SETTLED, updating map partition
-		this.offsetSettlements.get(partition).put(offset, true);
+		this.map.get(partition).settlements.put(offset, true);
 		
+		PartitionState state = this.map.get(partition);
 		// the first UNSETTLED offset is delivered
-		if (offset == this.firstUnsettledOffsets.get(partition)) {
+		if (offset == state.firstUnsettled) {
 			
-			// using Java 8 streams
-			
-			Optional<Long> firstUnsettledOffset = this.offsetSettlements.get(partition).entrySet().stream().filter(e -> e.getValue() == false).map(Map.Entry::getKey).findFirst();
+			Optional<Long> firstUnsettledOffset = state.settlements.entrySet().stream().filter(e -> e.getValue() == false).map(Map.Entry::getKey).findFirst();
 			
 			if (firstUnsettledOffset.isPresent()) {
 				
 				// first UNSETTLED offset found
-				this.firstUnsettledOffsets.put(partition, firstUnsettledOffset.get());
+				state.firstUnsettled = firstUnsettledOffset.get();
 				
 				// we need to remove from map all SETTLED offset there are before the first UNSETTLED offset
-				Set<Long> offsetToRemove = this.offsetSettlements.get(partition).keySet().stream().filter(k -> k < firstUnsettledOffset.get()).collect(Collectors.toSet());
+				Set<Long> offsetToRemove = state.settlements.keySet().stream().filter(k -> k < firstUnsettledOffset.get()).collect(Collectors.toSet());
 				
 				// offset to commit
 				Optional<Long> offsetToCommit = offsetToRemove.stream().reduce((a, b) -> b);
 				
 				if (offsetToCommit.isPresent()) {
-					this.offsets.put(partition, offsetToCommit.get());
-					this.offsetsFlag.put(partition, true);
+					state.offset = offsetToCommit.get();
+					state.flag = true;
 				}
 				
 				// removing all SETTLED offset before the first UNSETTLED we found
-				this.offsetSettlements.get(partition).keySet().removeAll(offsetToRemove);
+				state.settlements.keySet().removeAll(offsetToRemove);
 				
 			} else {
 				
 				// no other UNSETTLED offset, so the one just arrived is for commit
 				
 				long offsetToCommit = offset;
-				
-				this.offsets.put(partition, offsetToCommit);
-				this.offsetsFlag.put(partition, true);
-				
+				state.offset = offsetToCommit;
+				state.flag = true;
 				// all offset SETTLED, clear list
-				this.offsetSettlements.get(partition).clear();
+				state.settlements.clear();
 			}
 			
-		} else if (offset > this.firstUnsettledOffsets.get(partition)) {
+		} else if (offset > state.firstUnsettled) {
 			
 			// do nothing
 			
@@ -146,13 +144,11 @@ public class FullOffsetTracker<K, V> implements OffsetTracker<K, V> {
 		
 		Map<TopicPartition, OffsetAndMetadata> changedOffsets = new HashMap<>();
 		
-		for (Entry<Integer, Long> entry : this.offsets.entrySet()) {
-			
+		for (Entry<Integer, PartitionState> entry : this.map.entrySet()) {
 			// check if partition offset is changed and it needs to be committed
-			if (this.offsetsFlag.get(entry.getKey())) {
-						
+			if (entry.getValue().flag) {
 				changedOffsets.put(new TopicPartition(this.topic, entry.getKey()), 
-						new OffsetAndMetadata(entry.getValue()));
+						new OffsetAndMetadata(entry.getValue().offset));
 			}
 		}
 		
@@ -165,13 +161,13 @@ public class FullOffsetTracker<K, V> implements OffsetTracker<K, V> {
 		for (Entry<TopicPartition, OffsetAndMetadata> offset : offsets.entrySet()) {
 			
 			// be sure we are tracking the current partition and related offset
-			if (this.offsets.containsKey(offset.getKey().partition())) {
-			
+			if (this.map.containsKey(offset.getKey().partition())) {
+				PartitionState state = this.map.get(offset.getKey().partition());
 				// if offset tracked isn't changed during Kafka committing operation 
 				// (it means no other messages were acknowledged)
-				if (this.offsets.get(offset.getKey().partition()) == offset.getValue().offset()) {
+				if (state.offset == offset.getValue().offset()) {
 					// we can mark this offset as committed (not changed)
-					this.offsetsFlag.put(offset.getKey().partition(), false);
+					state.flag = false;
 				}
 			}
 		}
@@ -179,11 +175,7 @@ public class FullOffsetTracker<K, V> implements OffsetTracker<K, V> {
 
 	@Override
 	public synchronized void clear() {
-		
-		this.offsetSettlements.clear();
-		this.offsets.clear();
-		this.offsetsFlag.clear();
-		this.firstUnsettledOffsets.clear();
+		this.map.clear();
 	}
 
 }

--- a/src/main/java/enmasse/kafka/bridge/tracker/FullOffsetTracker.java
+++ b/src/main/java/enmasse/kafka/bridge/tracker/FullOffsetTracker.java
@@ -65,11 +65,7 @@ public class FullOffsetTracker<K, V> implements OffsetTracker<K, V> {
 	}
 	
 	@Override
-	public synchronized void track(String tag, ConsumerRecord<K, V> record) {
-	
-		// get partition and offset from delivery tag : <partition>_<offset>
-		int partition = Integer.valueOf(tag.substring(0, tag.indexOf("_")));
-		long offset = Long.valueOf(tag.substring(tag.indexOf("_") + 1));
+	public synchronized void track(int partition, long offset, ConsumerRecord<K, V> record) {
 		
 		if (!this.offsetSettlements.containsKey(partition)) {
 			
@@ -91,11 +87,7 @@ public class FullOffsetTracker<K, V> implements OffsetTracker<K, V> {
 	}
 
 	@Override
-	public synchronized void delivered(String tag) {
-		
-		// get partition and offset from delivery tag : <partition>_<offset>
-		int partition = Integer.valueOf(tag.substring(0, tag.indexOf("_")));
-		long offset = Long.valueOf(tag.substring(tag.indexOf("_") + 1));
+	public synchronized void delivered(int partition, long offset) {
 		
 		// offset SETTLED, updating map partition
 		this.offsetSettlements.get(partition).put(offset, true);

--- a/src/main/java/enmasse/kafka/bridge/tracker/OffsetTracker.java
+++ b/src/main/java/enmasse/kafka/bridge/tracker/OffsetTracker.java
@@ -26,21 +26,23 @@ import java.util.Map;
  * Interface for tracking offset for all partitions read by Kafka consumer
  */
 public interface OffsetTracker<K, V> {
-
+	
 	/**
 	 * Track information about Kafka consumer record and AMQP delivery
 	 *
-	 * @param tag		AMQP delivery tag
+	 * @param partition The Kafka partition
+	 * @param offset The offset within the partition
 	 * @param record	Kafka consumer record to track
 	 */
-	void track(String tag, ConsumerRecord<K, V> record);
+	void track(int partition, long offset, ConsumerRecord<K, V> record);
 	
 	/**
 	 * Confirm delivery of AMQP message
 	 * 
-	 * @param tag	AMQP delivery tag
+	 * @param partition The Kafka partition
+	 * @param offset The offset within the partition
 	 */
-	void delivered(String tag);
+	void delivered(int partition, long offset);
 	
 	/**
 	 * Get a map with changed offsets for all partitions

--- a/src/main/java/enmasse/kafka/bridge/tracker/SimpleOffsetTracker.java
+++ b/src/main/java/enmasse/kafka/bridge/tracker/SimpleOffsetTracker.java
@@ -32,12 +32,19 @@ import java.util.Map.Entry;
  */
 public class SimpleOffsetTracker<K, V> implements OffsetTracker<K, V> {
 
+	private static class PartitionState {
+		public long offset;
+		public boolean changed;
+		public PartitionState(long offset, boolean changed) {
+			this.offset = offset;
+			this.changed = changed;
+		}
+	}
+	
 	// Apache Kafka topic to track
 	private String topic;	
 	// map with each partition and related tracked offset
-	private Map<Integer, Long> offsets;
-	// map with changed status of offsets
-	private Map<Integer, Boolean> offsetsFlag;
+	private Map<Integer, PartitionState> offsets;
 	
 	/**
 	 * Contructor
@@ -45,10 +52,8 @@ public class SimpleOffsetTracker<K, V> implements OffsetTracker<K, V> {
 	 * @param topic	topic to track offset
 	 */
 	public SimpleOffsetTracker(String topic) {
-		
 		this.topic = topic;
 		this.offsets = new HashMap<>();
-		this.offsetsFlag = new HashMap<>();
 	}
 	
 	@Override
@@ -64,16 +69,16 @@ public class SimpleOffsetTracker<K, V> implements OffsetTracker<K, V> {
 			// map already contains partition but to handle "out of order" delivery
 			// we have to check that the current delivered offset is greater than
 			// the last committed offset
-			if (offset > this.offsets.get(partition)) {
-				this.offsets.put(partition, offset);
-				this.offsetsFlag.put(partition, true);
+			PartitionState state = this.offsets.get(partition);
+			if (offset > state.offset) {
+				state.offset = offset;
+				state.changed = true;
 			}
 			
 		} else {
 			
 			// new partition
-			this.offsets.put(partition, offset);
-			this.offsetsFlag.put(partition, true);
+			this.offsets.put(partition, new PartitionState(offset, true));
 		}
 	}
 
@@ -82,13 +87,12 @@ public class SimpleOffsetTracker<K, V> implements OffsetTracker<K, V> {
 		
 		Map<TopicPartition, OffsetAndMetadata> changedOffsets = new HashMap<>();
 		
-		for (Entry<Integer, Long> entry : this.offsets.entrySet()) {
+		for (Entry<Integer, PartitionState> entry : this.offsets.entrySet()) {
 			
 			// check if partition offset is changed and it needs to be committed
-			if (this.offsetsFlag.get(entry.getKey())) {
-						
+			if (entry.getValue().changed) {
 				changedOffsets.put(new TopicPartition(this.topic, entry.getKey()), 
-						new OffsetAndMetadata(entry.getValue()));
+						new OffsetAndMetadata(entry.getValue().offset));
 			}
 		}
 		
@@ -105,9 +109,10 @@ public class SimpleOffsetTracker<K, V> implements OffsetTracker<K, V> {
 			
 				// if offset tracked isn't changed during Kafka committing operation 
 				// (it means no other messages were acknowledged)
-				if (this.offsets.get(offset.getKey().partition()) == offset.getValue().offset()) {
+				PartitionState state = this.offsets.get(offset.getKey().partition());
+				if (state.offset == offset.getValue().offset()) {
 					// we can mark this offset as committed (not changed)
-					this.offsetsFlag.put(offset.getKey().partition(), false);
+					state.changed = false;
 				}
 			}
 		}
@@ -117,6 +122,5 @@ public class SimpleOffsetTracker<K, V> implements OffsetTracker<K, V> {
 	public synchronized void clear() {
 		
 		this.offsets.clear();
-		this.offsetsFlag.clear();
 	}
 }

--- a/src/main/java/enmasse/kafka/bridge/tracker/SimpleOffsetTracker.java
+++ b/src/main/java/enmasse/kafka/bridge/tracker/SimpleOffsetTracker.java
@@ -52,16 +52,12 @@ public class SimpleOffsetTracker<K, V> implements OffsetTracker<K, V> {
 	}
 	
 	@Override
-	public synchronized void track(String tag, ConsumerRecord<K, V> record) {
+	public synchronized void track(int partition, long offset, ConsumerRecord<K, V> record) {
 		// nothing
 	}
 	
 	@Override
-	public synchronized void delivered(String tag) {
-		
-		// get partition and offset from delivery tag : <partition>_<offset>
-		int partition = Integer.valueOf(tag.substring(0, tag.indexOf("_")));
-		long offset = Long.valueOf(tag.substring(tag.indexOf("_") + 1));
+	public synchronized void delivered(int partition, long offset) {
 		
 		if (this.offsets.containsKey(partition)) {
 			

--- a/src/test/java/enmasse/kafka/bridge/OffsetTrackerTest.java
+++ b/src/test/java/enmasse/kafka/bridge/OffsetTrackerTest.java
@@ -57,47 +57,46 @@ public class OffsetTrackerTest {
 		OffsetTracker<String, byte[]> offsetTracker  = new FullOffsetTracker<>("my_topic");
 		
 		for (ConsumerRecord<String, byte[]> record : this.records) {
-			String deliveryTag = String.format("%s_%s", record.partition(), record.offset());
-			offsetTracker.track(deliveryTag, record);
+			offsetTracker.track(record.partition(), record.offset(), record);
 		}
 		
 		LOG.info("0_2 deliverd");
-		offsetTracker.delivered("0_2");
+		offsetTracker.delivered(0, 2);
 		this.offsets = offsetTracker.getOffsets();
 		printOffsetsToCommit(this.offsets);
 		offsetTracker.commit(this.offsets);
 		Assert.assertTrue(this.offsets.isEmpty());
 		
 		LOG.info("0_3 deliverd");
-		offsetTracker.delivered("0_3");
+		offsetTracker.delivered(0, 3);
 		this.offsets = offsetTracker.getOffsets();
 		printOffsetsToCommit(this.offsets);
 		offsetTracker.commit(this.offsets);
 		Assert.assertTrue(this.offsets.isEmpty());
 		
 		LOG.info("0_0 deliverd");
-		offsetTracker.delivered("0_0");
+		offsetTracker.delivered(0, 0);
 		this.offsets = offsetTracker.getOffsets();
 		printOffsetsToCommit(this.offsets);
 		offsetTracker.commit(this.offsets);
 		Assert.assertTrue(this.offsets.get(new TopicPartition("my_topic", 0)).offset() == 0);
 		
 		LOG.info("0_1 deliverd");
-		offsetTracker.delivered("0_1");
+		offsetTracker.delivered(0, 1);
 		this.offsets = offsetTracker.getOffsets();
 		printOffsetsToCommit(this.offsets);
 		offsetTracker.commit(this.offsets);
 		Assert.assertTrue(this.offsets.get(new TopicPartition("my_topic", 0)).offset() == 3);
 		
 		LOG.info("0_4 deliverd");
-		offsetTracker.delivered("0_4");
+		offsetTracker.delivered(0, 4);
 		this.offsets = offsetTracker.getOffsets();
 		printOffsetsToCommit(this.offsets);
 		offsetTracker.commit(this.offsets);
 		Assert.assertTrue(this.offsets.get(new TopicPartition("my_topic", 0)).offset() == 4);
 		
 		LOG.info("0_5 deliverd");
-		offsetTracker.delivered("0_5");
+		offsetTracker.delivered(0, 5);
 		this.offsets = offsetTracker.getOffsets();
 		printOffsetsToCommit(this.offsets);
 		offsetTracker.commit(this.offsets);
@@ -112,47 +111,46 @@ public class OffsetTrackerTest {
 		OffsetTracker<String, byte[]> offsetTracker  = new FullOffsetTracker<>("my_topic");
 		
 		for (ConsumerRecord<String, byte[]> record : this.records) {
-			String deliveryTag = String.format("%s_%s", record.partition(), record.offset());
-			offsetTracker.track(deliveryTag, record);
+			offsetTracker.track(record.partition(), record.offset(), record);
 		}
 		
 		LOG.info("0_0 deliverd");
-		offsetTracker.delivered("0_0");
+		offsetTracker.delivered(0, 0);
 		this.offsets = offsetTracker.getOffsets();
 		printOffsetsToCommit(this.offsets);
 		offsetTracker.commit(this.offsets);
 		Assert.assertTrue(this.offsets.get(new TopicPartition("my_topic", 0)).offset() == 0);
 		
 		LOG.info("0_1 deliverd");
-		offsetTracker.delivered("0_1");
+		offsetTracker.delivered(0, 1);
 		this.offsets = offsetTracker.getOffsets();
 		printOffsetsToCommit(this.offsets);
 		offsetTracker.commit(this.offsets);
 		Assert.assertTrue(this.offsets.get(new TopicPartition("my_topic", 0)).offset() == 1);
 		
 		LOG.info("0_2 deliverd");
-		offsetTracker.delivered("0_2");
+		offsetTracker.delivered(0, 2);
 		this.offsets = offsetTracker.getOffsets();
 		printOffsetsToCommit(this.offsets);
 		offsetTracker.commit(this.offsets);
 		Assert.assertTrue(this.offsets.get(new TopicPartition("my_topic", 0)).offset() == 2);
 		
 		LOG.info("0_3 deliverd");
-		offsetTracker.delivered("0_3");
+		offsetTracker.delivered(0, 3);
 		this.offsets = offsetTracker.getOffsets();
 		printOffsetsToCommit(this.offsets);
 		offsetTracker.commit(this.offsets);
 		Assert.assertTrue(this.offsets.get(new TopicPartition("my_topic", 0)).offset() == 3);
 		
 		LOG.info("0_4 deliverd");
-		offsetTracker.delivered("0_4");
+		offsetTracker.delivered(0, 4);
 		this.offsets = offsetTracker.getOffsets();
 		printOffsetsToCommit(this.offsets);
 		offsetTracker.commit(this.offsets);
 		Assert.assertTrue(this.offsets.get(new TopicPartition("my_topic", 0)).offset() == 4);
 		
 		LOG.info("0_5 deliverd");
-		offsetTracker.delivered("0_5");
+		offsetTracker.delivered(0, 5);
 		this.offsets = offsetTracker.getOffsets();
 		printOffsetsToCommit(this.offsets);
 		offsetTracker.commit(this.offsets);
@@ -167,47 +165,46 @@ public class OffsetTrackerTest {
 		OffsetTracker<String, byte[]> offsetTracker  = new SimpleOffsetTracker<>("my_topic");
 		
 		for (ConsumerRecord<String, byte[]> record : records) {
-			String deliveryTag = String.format("%s_%s", record.partition(), record.offset());
-			offsetTracker.track(deliveryTag, record);
+			offsetTracker.track(record.partition(), record.offset(), record);
 		}
 		
 		LOG.info("0_2 deliverd");
-		offsetTracker.delivered("0_2");
+		offsetTracker.delivered(0, 2);
 		this.offsets = offsetTracker.getOffsets();
 		printOffsetsToCommit(this.offsets);
 		offsetTracker.commit(this.offsets);
 		Assert.assertTrue(this.offsets.get(new TopicPartition("my_topic", 0)).offset() == 2);
 		
 		LOG.info("0_3 deliverd");
-		offsetTracker.delivered("0_3");
+		offsetTracker.delivered(0, 3);
 		this.offsets = offsetTracker.getOffsets();
 		printOffsetsToCommit(this.offsets);
 		offsetTracker.commit(this.offsets);
 		Assert.assertTrue(this.offsets.get(new TopicPartition("my_topic", 0)).offset() == 3);
 		
 		LOG.info("0_0 deliverd");
-		offsetTracker.delivered("0_0");
+		offsetTracker.delivered(0, 0);
 		this.offsets = offsetTracker.getOffsets();
 		printOffsetsToCommit(this.offsets);
 		offsetTracker.commit(this.offsets);
 		Assert.assertTrue(this.offsets.isEmpty());
 		
 		LOG.info("0_1 deliverd");
-		offsetTracker.delivered("0_1");
+		offsetTracker.delivered(0, 1);
 		this.offsets = offsetTracker.getOffsets();
 		printOffsetsToCommit(this.offsets);
 		offsetTracker.commit(this.offsets);
 		Assert.assertTrue(this.offsets.isEmpty());
 		
 		LOG.info("0_4 deliverd");
-		offsetTracker.delivered("0_4");
+		offsetTracker.delivered(0, 4);
 		this.offsets = offsetTracker.getOffsets();
 		printOffsetsToCommit(this.offsets);
 		offsetTracker.commit(this.offsets);
 		Assert.assertTrue(this.offsets.get(new TopicPartition("my_topic", 0)).offset() == 4);
 		
 		LOG.info("0_5 deliverd");
-		offsetTracker.delivered("0_5");
+		offsetTracker.delivered(0, 5);
 		this.offsets = offsetTracker.getOffsets();
 		printOffsetsToCommit(this.offsets);
 		offsetTracker.commit(this.offsets);
@@ -222,47 +219,46 @@ public class OffsetTrackerTest {
 		OffsetTracker<String, byte[]> offsetTracker  = new SimpleOffsetTracker<>("my_topic");
 		
 		for (ConsumerRecord<String, byte[]> record : records) {
-			String deliveryTag = String.format("%s_%s", record.partition(), record.offset());
-			offsetTracker.track(deliveryTag, record);
+			offsetTracker.track(record.partition(), record.offset(), record);
 		}
 		
 		LOG.info("0_0 deliverd");
-		offsetTracker.delivered("0_0");
+		offsetTracker.delivered(0, 0);
 		this.offsets = offsetTracker.getOffsets();
 		printOffsetsToCommit(this.offsets);
 		offsetTracker.commit(this.offsets);
 		Assert.assertTrue(this.offsets.get(new TopicPartition("my_topic", 0)).offset() == 0);
 		
 		LOG.info("0_1 deliverd");
-		offsetTracker.delivered("0_1");
+		offsetTracker.delivered(0, 1);
 		this.offsets = offsetTracker.getOffsets();
 		printOffsetsToCommit(this.offsets);
 		offsetTracker.commit(this.offsets);
 		Assert.assertTrue(this.offsets.get(new TopicPartition("my_topic", 0)).offset() == 1);
 		
 		LOG.info("0_2 deliverd");
-		offsetTracker.delivered("0_2");
+		offsetTracker.delivered(0, 2);
 		this.offsets = offsetTracker.getOffsets();
 		printOffsetsToCommit(this.offsets);
 		offsetTracker.commit(this.offsets);
 		Assert.assertTrue(this.offsets.get(new TopicPartition("my_topic", 0)).offset() == 2);
 		
 		LOG.info("0_3 deliverd");
-		offsetTracker.delivered("0_3");
+		offsetTracker.delivered(0, 3);
 		this.offsets = offsetTracker.getOffsets();
 		printOffsetsToCommit(this.offsets);
 		offsetTracker.commit(this.offsets);
 		Assert.assertTrue(this.offsets.get(new TopicPartition("my_topic", 0)).offset() == 3);
 		
 		LOG.info("0_4 deliverd");
-		offsetTracker.delivered("0_4");
+		offsetTracker.delivered(0, 4);
 		this.offsets = offsetTracker.getOffsets();
 		printOffsetsToCommit(this.offsets);
 		offsetTracker.commit(this.offsets);
 		Assert.assertTrue(this.offsets.get(new TopicPartition("my_topic", 0)).offset() == 4);
 		
 		LOG.info("0_5 deliverd");
-		offsetTracker.delivered("0_5");
+		offsetTracker.delivered(0, 5);
 		this.offsets = offsetTracker.getOffsets();
 		printOffsetsToCommit(this.offsets);
 		offsetTracker.commit(this.offsets);


### PR DESCRIPTION
Tidies up the `OffsetTracker` API and implementations in a number of ways:

1. Drops using the opaque `String tag` in the API for `int partition` and `long offset`, since the offset tracker doesn't need to know about the tags used for the vertx `EventBus`
2. Refactors the implementations of `OffsetTracker` to avoid using multiple `Map`s