### PR TITLE
Add AMQPS support (TLS) in the CLIENT mode

### DIFF
--- a/src/main/java/enmasse/kafka/bridge/Bridge.java
+++ b/src/main/java/enmasse/kafka/bridge/Bridge.java
@@ -16,6 +16,7 @@
 
 package enmasse.kafka.bridge;
 
+import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -43,6 +44,8 @@ import io.vertx.proton.ProtonSender;
 import io.vertx.proton.ProtonServer;
 import io.vertx.proton.ProtonServerOptions;
 import io.vertx.proton.ProtonSession;
+import io.vertx.core.net.PemKeyCertOptions;
+import io.vertx.core.net.PemTrustOptions;
 
 /**
  * Main bridge class listening for connections
@@ -267,6 +270,20 @@ public class Bridge extends AbstractVerticle {
 		ProtonClientOptions options = new ProtonClientOptions();
 		options.setConnectTimeout(1000);
 		options.setReconnectAttempts(-1).setReconnectInterval(1000); // reconnect forever, every 200 millisecs
+
+		if (this.bridgeConfigProperties.getAmqpConfigProperties().getCertDir() != null && this.bridgeConfigProperties.getAmqpConfigProperties().getCertDir().length() > 0) {
+			String certDir = this.bridgeConfigProperties.getAmqpConfigProperties().getCertDir();
+			LOG.info("Enabling SSL configuration for AMQP with TLS certificates from {}", certDir);
+			options.setSsl(true)
+					.addEnabledSaslMechanism("EXTERNAL")
+					.setHostnameVerificationAlgorithm("")
+					.setPemTrustOptions(new PemTrustOptions()
+							.addCertPath(new File(certDir, "ca.crt").getAbsolutePath()))
+					.setPemKeyCertOptions(new PemKeyCertOptions()
+							.addCertPath(new File(certDir, "tls.crt").getAbsolutePath())
+							.addKeyPath(new File(certDir, "tls.key").getAbsolutePath()));
+		}
+
 		return options;
 	}
 	

--- a/src/main/java/enmasse/kafka/bridge/config/AmqpConfigProperties.java
+++ b/src/main/java/enmasse/kafka/bridge/config/AmqpConfigProperties.java
@@ -31,12 +31,14 @@ public class AmqpConfigProperties {
     private static final int DEFAULT_PORT = 5672;
     private static final int DEFAULT_FLOW_CREDIT = 1024;
     private static final String DEFAULT_MESSAGE_CONVERTER = "enmasse.kafka.bridge.converter.DefaultMessageConverter";
+    private static final String DEFAULT_CERT_DIR = null;
 
     private AmqpMode mode = DEFAULT_AMQP_MODE;
     private int flowCredit = DEFAULT_FLOW_CREDIT;
     private String host = DEFAULT_HOST;
     private int port = DEFAULT_PORT;
     private String messageConverter = DEFAULT_MESSAGE_CONVERTER;
+    private String certDir = DEFAULT_CERT_DIR;
 
     /**
      * Get the AMQP receiver flow credit
@@ -134,6 +136,26 @@ public class AmqpConfigProperties {
      */
     public AmqpConfigProperties setMessageConverter(String messageConverter) {
         this.messageConverter = messageConverter;
+        return this;
+    }
+
+    /**
+     * Get the directory with the TLS certificates files
+     *
+     * @return
+     */
+    public String getCertDir() {
+        return this.certDir;
+    }
+
+    /**
+     * Set the directory with the TLS certificates files
+     *
+     * @param certDir  Path to the TLS certificate files
+     * @return  this instance for setter chaining
+     */
+    public AmqpConfigProperties setCertDir(String certDir) {
+        this.certDir = certDir;
         return this;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,4 +16,5 @@ amqp.flowCredit=100
 amqp.mode=SERVER
 amqp.host=0.0.0.0
 amqp.port=5672
+amqp.certDir=
 amqp.messageConverter=enmasse.kafka.bridge.converter.DefaultMessageConverter

--- a/src/main/sh/run_bridge.sh
+++ b/src/main/sh/run_bridge.sh
@@ -11,6 +11,6 @@ fi
 # configuring the bridge to work in "client" mode connecting to the messaging (router) layer
 export AMQP_MODE="CLIENT"
 export AMQP_HOST=$MESSAGING_SERVICE_HOST
-export AMQP_PORT=$MESSAGING_SERVICE_PORT_INTERNAL
+export AMQP_PORT=$MESSAGING_SERVICE_PORT_AMQPS_BROKER
 
 exec java -Dvertx.cacheDirBase=/tmp -jar /amqp-kafka-bridge.jar


### PR DESCRIPTION
In the CLIENT mode, when the environment variable `AMQP_CERT_DIR` / configuration property `amqp.certDir` is specified, the bridge will open the AMQP connection with SASL EXTERNAL and the TLS certificates from the `$AMQP_CERT_DIR` path (ca.crt, tls.crt and tls.key).

Additionally `run_bridge.sh` is now using `$MESSAGING_SERVICE_PORT_AMQPS_BROKER` for the port where to connect. This is the port where link routing is enabled in EnMasse.